### PR TITLE
Add method to export metadata in dictionary

### DIFF
--- a/hachoir/metadata/metadata.py
+++ b/hachoir/metadata/metadata.py
@@ -190,14 +190,6 @@ class Metadata(Logger):
 
         If priority is too small, metadata are empty and so None is returned.
 
-        >>> print RootMetadata().exportPlaintext()
-        None
-        >>> meta = RootMetadata()
-        >>> meta.copyright = unicode("© Hachoir", "UTF-8")
-        >>> print repr(meta.exportPlaintext())
-        [u'Metadata:', u'- Copyright: \xa9 Hachoir']
-
-        @see __str__() and __unicode__()
         """
         if priority is not None:
             priority = max(priority, MIN_PRIORITY)
@@ -225,8 +217,6 @@ class Metadata(Logger):
                     value = makeUnicode(item.value)
                 text[title][field] = value
         return text
-
-
 
     def __bool__(self):
         return any(item for item in self.__data.values())

--- a/hachoir/metadata/metadata.py
+++ b/hachoir/metadata/metadata.py
@@ -179,6 +179,55 @@ class Metadata(Logger):
         else:
             return None
 
+    def exportDictionary(self, priority=None, human=True, title=None):
+        r"""
+        Convert metadata to python Dictionary and skip datas
+        with priority lower than specified priority.
+
+        Default priority is Metadata.MAX_PRIORITY. If human flag is True, data
+        key are translated to better human name (eg. "bit_rate" becomes
+        "Bit rate") which may be translated using gettext.
+
+        If priority is too small, metadata are empty and so None is returned.
+
+        >>> print RootMetadata().exportPlaintext()
+        None
+        >>> meta = RootMetadata()
+        >>> meta.copyright = unicode("© Hachoir", "UTF-8")
+        >>> print repr(meta.exportPlaintext())
+        [u'Metadata:', u'- Copyright: \xa9 Hachoir']
+
+        @see __str__() and __unicode__()
+        """
+        if priority is not None:
+            priority = max(priority, MIN_PRIORITY)
+            priority = min(priority, MAX_PRIORITY)
+        else:
+            priority = MAX_PRIORITY
+        if not title:
+            title = self.header
+        text = {}
+        text[title] = {}
+        for data in sorted(self):
+            if priority < data.priority:
+                break
+            if not data.values:
+                continue
+            if human:
+                field = data.description
+            else:
+                field = data.key
+            text[title][field] = {}
+            for item in data.values:
+                if human:
+                    value = item.text
+                else:
+                    value = makeUnicode(item.value)
+                text[title][field] = value
+        return text
+
+
+
     def __bool__(self):
         return any(item for item in self.__data.values())
 
@@ -251,6 +300,22 @@ class MultipleMetadata(RootMetadata):
             return text
         else:
             return None
+
+    def exportDictionary(self, priority=None, human=True):
+        common = Metadata.exportDictionary(self, priority, human)
+        if common:
+            text = common
+        else:
+            text = {}
+        for key, metadata in self.__groups.items():
+            if not human:
+                title = key
+            else:
+                title = None
+            value = metadata.exportDictionary(priority, human, title=title)
+            if value:
+                text.update(value)
+        return text
 
 
 def registerExtractor(parser, extractor):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -46,6 +46,31 @@ class TestMetadata(unittest.TestCase):
             sys.stdout.write("ok\n")
         return metadata
 
+    def test_dict_output(self):
+        required_meta = {'Common': {'duration': '0:00:17.844000',
+                                    'creation_date': '2006-08-16 11:04:36',
+                                    'producer': 'libebml v0.7.7 + libmatroska v0.8.0',
+                                    'mime_type': 'video/x-matroska',
+                                    'endian': 'Big endian'
+                                    },
+                         'video[1]': {'language': 'French',
+                                      'width': '384',
+                                      'height': '288',
+                                      'compression': 'V_MPEG4/ISO/AVC
+                                      },
+                         'audio[1]': {'title': 'travail = aliénation (extrait)',
+                                      'language': 'French',
+                                      'nb_channel': '1',
+                                      'sample_rate': '44100.0',
+                                      'compression': 'A_VORBIS'
+                                      }
+                         }
+        parser = createParser(os.path.join(DATADIR, "flashmob.mkv"))
+        extractor = extractMetadata(parser)
+        meta = extractor.exportDictionary(human=False)
+        parser.stream._input.close()
+        self.assertEqual(required_meta, meta)
+
     def check_attr(self, metadata, name, value):
         if self.verbose:
             sys.stdout.write("  - Check metadata %s=%s: " %

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -65,10 +65,10 @@ class TestMetadata(unittest.TestCase):
                                       'compression': 'A_VORBIS'
                                       }
                          }
-        parser = createParser(os.path.join(DATADIR, "flashmob.mkv"))
-        extractor = extractMetadata(parser)
+        with createParser(os.path.join(DATADIR, "flashmob.mkv")) as parser:
+            extractor = extractMetadata(parser)
         meta = extractor.exportDictionary(human=False)
-        parser.stream._input.close()
+
         self.assertEqual(required_meta, meta)
 
     def check_attr(self, metadata, name, value):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -56,7 +56,7 @@ class TestMetadata(unittest.TestCase):
                          'video[1]': {'language': 'French',
                                       'width': '384',
                                       'height': '288',
-                                      'compression': 'V_MPEG4/ISO/AVC
+                                      'compression': 'V_MPEG4/ISO/AVC'
                                       },
                          'audio[1]': {'title': 'travail = aliénation (extrait)',
                                       'language': 'French',


### PR DESCRIPTION
Usage is almost identical to exportPlaintext. Exports metadata in an easy to access dictionary.

I've been using this modification with the Python 2 version of Hachior in Watcher for a few months now and it is very handy. I've tested this commit to work on MKV and MP4 movies as well as a handful of image formats using Python 3.6.0 on Windows 10.

```
>>> from hachoir.parser import createParser
>>> from hachoir.metadata import extractMetadata
>>> parser = createParser('/home/nsb/images/wallpaper/nebula.jpg')
>>> extractor = extractMetadata(parser)
>>> metadata = extractor.exportDictionary(human=False)
>>> print(json.dumps(metadata, indent=2))
{
  "Metadata": {
    "width": "2560",
    "height": "1600",
    "image_orientation": "Horizontal (normal)",
    "bits_per_pixel": "24",
    "pixel_format": "YCbCr",
    "creation_date": "2013-06-19 20:29:34",
    "city": "\\x1b%G",
    "compression": "JPEG (Baseline)",
    "thumbnail_size": "1884",
    "producer": "Adobe Photoshop CS6 (Windows)",
    "comment": "JPEG quality: 94% (approximate)",
    "mime_type": "image/jpeg",
    "endian": "Big endian"
  }
}
```

Or an example output of a video file:
```
>>> print(json.dumps(filedata, indent=2))               
{                                                       
  "Common": {                                           
    "Duration": "1 hours 42 min 45 sec",                
    "Creation date": "2016-06-15 18:34:47",             
    "Producer": "libebml v1.3.3 + libmatroska v1.4.4",  
    "MIME type": "video/x-matroska",                    
    "Endianness": "Big endian"                          
  },                                                    
  "Video stream": {                                     
    "Language": "English",                              
    "Image width": "1920 pixels",                       
    "Image height": "1080 pixels",                      
    "Compression": "V_MPEG4/ISO/AVC"                    
  },                                                    
  "Audio stream": {                                     
    "Language": "English",                              
    "Channel": "6",                                     
    "Sample rate": "48.0 kHz",                          
    "Bits/sample": "24 bits",                           
    "Compression": "A_DTS"                              
  },                                                    
  "Subtitle": {                                         
    "Language": "Spanish",                              
    "Compression": "S_HDMV/PGS"                         
  }                                                     
}                                                       
```
