### PR TITLE
Fix EditableTimestampMac32 field editing

### DIFF
--- a/hachoir/editor/typed_field.py
+++ b/hachoir/editor/typed_field.py
@@ -279,7 +279,7 @@ class EditableTimestampMac32(EditableFixedField):
         self._value = value
 
     def _write(self, output):
-        timestamp = int((self.value - self.minval).total_seconds())
+        timestamp = int((self._value - self.minval).total_seconds())
         output.writeBits(self._size, timestamp, self._parent.endian)
 
 

--- a/hachoir/stream/output.py
+++ b/hachoir/stream/output.py
@@ -42,7 +42,7 @@ class OutputStream(object):
                     self._byte |= 1
                 else:
                     self._byte |= 128
-            self._output.write(chr(self._byte))
+            self._output.write(bytes([self._byte]))
             self._byte = 0
         else:
             if state:
@@ -89,7 +89,7 @@ class OutputStream(object):
             else:
                 byte = (value & 0xFF)
                 value >>= 8
-            self._output.write(chr(byte))
+            self._output.write(bytes([byte]))
 
         # Keep last bits
         assert 0 <= count < 8


### PR DESCRIPTION
Also fix editing in general (writing of `bytes` as `chr` is no good on Python3).