### PR TITLE
ext2: fix directory digging

### DIFF
--- a/hachoir/parser/file_system/ext2.py
+++ b/hachoir/parser/file_system/ext2.py
@@ -295,7 +295,9 @@ class Inode(FieldSet):
 
 
 class Directory(Parser):
-    PARSER_TAGS = {}
+    PARSER_TAGS = {
+        "description": "Directory of EXT2/EXT3 file system",
+    }
     endian = LITTLE_ENDIAN
 
     def createFields(self):


### PR DESCRIPTION
This change fixes a bug triggered when pressing ' ' key in urwid
interface on inode[1]/block[0] in group[0] for digging root directory.

How to reproduce:

 1. make an input file:
    $ dd if=/dev/zero of=a.ext2 count=5000 bs=1024
    $ mkfs.ext2 a.ext2

 2. run urwid interface,
 3. expand group[0] with enter key,
 4. open inode[1]block[0] with space key
 5. You will get following error messages and urwid interface stops.

  Pending messages:
  [*][err!] Error getting description of /: 'Directory' object has no attribute 'PARSER_TAGS'
  Traceback (most recent call last):
    File "/home/yamato/var/hachoir3-github/hachoir/parser/parser.py", line 76, in _getDescription
      self._description = self.createDescription()
    File "/home/yamato/var/hachoir3-github/hachoir/parser/parser.py", line 51, in createDescription
      return self.PARSER_TAGS["description"]
  AttributeError: 'Directory' object has no attribute 'PARSER_TAGS'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/home/yamato/var/hachoir3/hachoir-urwid", line 3, in <module>
      main()
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 832, in main
      "display_value": values.display_value,
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 740, in exploreFieldSet
      ui.run_wrapper(run)
    File "/usr/lib64/python3.6/site-packages/urwid/display_common.py", line 755, in run_wrapper
      return fn()
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 724, in run
      canvas = top.render(size, focus=True)
    File "/usr/lib64/python3.6/site-packages/urwid/widget.py", line 140, in cached_render
      canv = fn(self, size, focus=focus)
    File "/usr/lib64/python3.6/site-packages/urwid/container.py", line 1082, in render
      focus and self.focus_part == 'body')
    File "/usr/lib64/python3.6/site-packages/urwid/widget.py", line 140, in cached_render
      canv = fn(self, size, focus=focus)
    File "/usr/lib64/python3.6/site-packages/urwid/widget.py", line 1749, in render
      canv = get_delegate(self).render(size, focus=focus)
    File "/usr/lib64/python3.6/site-packages/urwid/widget.py", line 140, in cached_render
      canv = fn(self, size, focus=focus)
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 412, in render
      canvas = ListBox.render(self, size, focus)
    File "/usr/lib64/python3.6/site-packages/urwid/widget.py", line 140, in cached_render
      canv = fn(self, size, focus=focus)
    File "/usr/lib64/python3.6/site-packages/urwid/listbox.py", line 454, in render
      (maxcol, maxrow), focus=focus)
    File "/usr/lib64/python3.6/site-packages/urwid/listbox.py", line 336, in calculate_visible
      self._set_focus_complete( (maxcol, maxrow), focus )
    File "/usr/lib64/python3.6/site-packages/urwid/listbox.py", line 701, in _set_focus_complete
      (maxcol,maxrow), focus)
    File "/usr/lib64/python3.6/site-packages/urwid/listbox.py", line 671, in _set_focus_first_selectable
      (maxcol, maxrow), focus=focus)
    File "/usr/lib64/python3.6/site-packages/urwid/listbox.py", line 339, in calculate_visible
      focus_widget, focus_pos = self.body.get_focus()
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 328, in get_focus
      return self._get(self.focus)
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 324, in _get
      self.update(pos)
    File "/home/yamato/var/hachoir3-github/hachoir/urwid_ui.py", line 296, in update
      if node.field.description and self.flags & self.display_description:
    File "/home/yamato/var/hachoir3-github/hachoir/parser/parser.py", line 82, in _getDescription
      self._description = self.PARSER_TAGS["description"]
  AttributeError: 'Directory' object has no attribute 'PARSER_TAGS'

Signed-off-by: Masatake YAMATO <yamato@redhat.com>